### PR TITLE
Seekable Format Empty String Bug Fix

### DIFF
--- a/contrib/seekable_format/tests/seekable_tests.c
+++ b/contrib/seekable_format/tests/seekable_tests.c
@@ -189,18 +189,18 @@ int main(int argc, const char** argv)
 
     printf("Test %u - check ZSTD magic in compressing empty string: ", testNb++);
     { // compressing empty string should return a zstd header
-        char *data_in = (char *) malloc(255 * sizeof(char));
-        assert(data_in != NULL);
-        data_in = "\0";
-
-        char *data_out = (char *) malloc(255 * 255 * sizeof(char));
-        assert(data_out != NULL);
+        size_t const capacity = 255;
+        char* inBuffer = malloc(capacity);
+        assert(inBuffer != NULL);
+        inBuffer[0] = '\0';
+        void* const outBuffer = malloc(capacity);
+        assert(outBuffer != NULL);
 
         ZSTD_seekable_CStream *s = ZSTD_seekable_createCStream();
-        ZSTD_seekable_initCStream(s, 1, 1, 1024 * 1024);
+        ZSTD_seekable_initCStream(s, 1, 1, 255);
 
-        ZSTD_inBuffer input = { data_in, 0, 0 };
-        ZSTD_outBuffer output = { data_out, 255*255, 0 };
+        ZSTD_inBuffer input = { .src=inBuffer, .pos=0, .size=0 };
+        ZSTD_outBuffer output = { .dst=outBuffer, .pos=0, .size=capacity };
 
         ZSTD_seekable_compressStream(s, &output, &input);
         ZSTD_seekable_endStream(s, &output);
@@ -208,10 +208,14 @@ int main(int argc, const char** argv)
         if((((char*)output.dst)[0] != '\x28') | (((char*)output.dst)[1] != '\xb5') | (((char*)output.dst)[2] != '\x2f') | (((char*)output.dst)[3] != '\xfd')) {
             printf("%#02x %#02x %#02x %#02x\n", ((char*)output.dst)[0], ((char*)output.dst)[1] , ((char*)output.dst)[2] , ((char*)output.dst)[3] );
 
+            free(inBuffer);
+            free(outBuffer);
             ZSTD_seekable_freeCStream(s);
             goto _test_error;
         }
 
+        free(inBuffer);
+        free(outBuffer);
         ZSTD_seekable_freeCStream(s);
     }
     printf("Success!\n");

--- a/contrib/seekable_format/zstdseek_compress.c
+++ b/contrib/seekable_format/zstdseek_compress.c
@@ -350,7 +350,7 @@ size_t ZSTD_seekable_writeSeekTable(ZSTD_frameLog* fl, ZSTD_outBuffer* output)
 
 size_t ZSTD_seekable_endStream(ZSTD_seekable_CStream* zcs, ZSTD_outBuffer* output)
 {
-    if (!zcs->writingSeekTable && zcs->frameDSize) {
+    if (!zcs->writingSeekTable) {
         const size_t endFrame = ZSTD_seekable_endFrame(zcs, output);
         if (ZSTD_isError(endFrame)) return endFrame;
         /* return an accurate size hint */


### PR DESCRIPTION
This PR is a followup to a previous PR. The goal of the previous PR was to fix a small bug in `seekable_format` that led to the omission of the ZSTD MAGIC when compressing an empty string.

I have validated the bug fix with the test case provided, but have created this PR to fix some minor issues (forgetting to free malloc'd memory in the test case).

Note that, upon further investigation, it seems that this issue occured whenever `ZSTD_inBuffer.size == 0`, rather than explicitly for an empty string (NULL first char). For example, if we set the size of inBuffer to 255, set the first char to `NULL`, and set `ZSTD_inBuffer.size == sizeof(inBuffer)`, the ZSTD MAGIC was present. On the other hand, if we set `ZSTD_inBuffer.size == strlen(inBuffer)` , the ZSTD MAGIC was omitted.